### PR TITLE
added methods for calc to use chem_space subset, add method to manual…

### DIFF
--- a/src/qmof_thermo/core/calc.py
+++ b/src/qmof_thermo/core/calc.py
@@ -80,10 +80,18 @@ def _load_phase_diagram_for_space(
 
     key = str(space)  # e.g. "('Ba', 'O', 'V')"
     if key not in space_mapping:
-        raise ValueError(
-            f"No phase diagram found for chemical space {space}. "
-            f"Known spaces: {len(space_mapping)}"
-        )
+        # Exact space not found; fall back to a superset space
+        space_set = set(space)
+        for candidate_key in space_mapping:
+            if all(f"'{el}'" in candidate_key for el in space_set):
+                key = candidate_key
+                break
+        else:
+            raise ValueError(
+                f"No phase diagram found for chemical space {space} "
+                f"or any superset. Known spaces: {len(space_mapping)}"
+                f"Try running setup_pd.setup_phase_diagram_for_space to build the specifc reference phase diagram for chemical space {space}."
+            )
 
     pd_filename = f"{key}_phase_diagram.json"
     pd_path = pd_dir / pd_filename


### PR DESCRIPTION
Included fix in`calc.def energy_above_hull_from_structure()` where input structures couldn't use parent phase diagrams (phase diagram files which had a chemical space greater than but still including the input structure's chemical space), fixed via finding first instance of a chemical space which includes input structure's chemical space as a subset. 

Also included a public method in setup.py that allowed users to generate a phase diagram using a specific chemical space. This should fix potential instances where parent phase diagram's don't exist, but reference structures exist collectively covering all elements of a possible input structure.

Requesting code review, in addition to possible readme file changes.